### PR TITLE
Add {benchmark,test}_name to db schema.

### DIFF
--- a/backend/db/migrations/20210013150054_add_benchmarks_table.up.sql
+++ b/backend/db/migrations/20210013150054_add_benchmarks_table.up.sql
@@ -4,6 +4,7 @@
 		commit varchar(50) NOT NULL,
 		branch varchar(256),
 		pull_number integer,
-		name varchar(256),
+		benchmark_name varchar(256),
+		test_name  varchar(256) NOT NULL,
 		metrics jsonb
 	);

--- a/backend/utils/benchmarksrun_to_benchmarks.sql
+++ b/backend/utils/benchmarksrun_to_benchmarks.sql
@@ -2,7 +2,7 @@
 -- Populates the benchmarks table with all the records from benchmarksrun.
 BEGIN;
 INSERT INTO
-    benchmarks(run_at, repo_id, commit, branch, pull_number, name, metrics)
+    benchmarks(run_at, repo_id, commit, branch, pull_number, test_name, metrics)
 SELECT
     to_timestamp(timestamp) AS run_at,
     split_part(branch, '/', 1) || '/' || split_part(branch, '/', 2)  AS repo_id,
@@ -19,7 +19,7 @@ SELECT
     ELSE
         NULL
     END AS pull_number,
-    NULL AS name,
+    name AS test_name,
     ('{"time":' || time ||
     ', "ops_per_sec":' || ops_per_sec || 
     ', "mbs_per_sec":' || mbs_per_sec || '}')::jsonb AS metrics

--- a/frontend-new/graphql_schema.json
+++ b/frontend-new/graphql_schema.json
@@ -1,139 +1,107 @@
 {
   "__schema": {
-    "directives": [
-      {
-        "args": [
-          {
-            "name": "if",
-            "defaultValue": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "description": null
-          }
-        ],
-        "name": "include",
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
-        "description": null
-      },
-      {
-        "args": [
-          {
-            "name": "if",
-            "defaultValue": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "description": null
-          }
-        ],
-        "name": "skip",
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
-        "description": null
-      }
-    ],
     "queryType": {
-      "name": "query_root"
+      "name": "query_root",
+      "__typename": "__Type"
+    },
+    "mutationType": {
+      "name": "mutation_root",
+      "__typename": "__Type"
     },
     "subscriptionType": {
-      "name": "subscription_root"
+      "name": "subscription_root",
+      "__typename": "__Type"
     },
     "types": [
       {
-        "inputFields": null,
         "kind": "SCALAR",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "Boolean",
-        "enumValues": null,
         "description": null,
-        "fields": null
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "SCALAR",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "Float",
-        "enumValues": null,
         "description": null,
-        "fields": null
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "SCALAR",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "ID",
-        "enumValues": null,
         "description": null,
-        "fields": null
-      },
-      {
+        "fields": null,
         "inputFields": null,
-        "kind": "SCALAR",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "Int",
         "enumValues": null,
-        "description": null,
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "SCALAR",
+        "name": "Int",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "Int_comparison_exp",
+        "description": "expression to compare columns of type Int. All fields are combined with logical 'AND'.",
+        "fields": null,
         "inputFields": [
           {
             "name": "_eq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_in",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -143,55 +111,67 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_is_null",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_neq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_nin",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -201,76 +181,90 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "Int_comparison_exp",
         "enumValues": null,
-        "description": "expression to compare columns of type Int. All fields are combined with logical 'AND'.",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "SCALAR",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "String",
-        "enumValues": null,
         "description": null,
-        "fields": null
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "String_comparison_exp",
+        "description": "expression to compare columns of type String. All fields are combined with logical 'AND'.",
+        "fields": null,
         "inputFields": [
           {
             "name": "_eq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_ilike",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_in",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -280,75 +274,91 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_is_null",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_like",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_neq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_nilike",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_nin",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -358,65 +368,67 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_nlike",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_nsimilar",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_similar",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "String_comparison_exp",
         "enumValues": null,
-        "description": "expression to compare columns of type String. All fields are combined with logical 'AND'.",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "__Directive",
-        "enumValues": null,
         "description": null,
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "args",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -429,30 +441,37 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "__InputValue",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "description",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "locations",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -465,231 +484,270 @@
                   "ofType": {
                     "kind": "ENUM",
                     "name": "__DirectiveLocation",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          }
-        ]
-      },
-      {
-        "inputFields": null,
-        "kind": "ENUM",
-        "possibleTypes": null,
-        "interfaces": null,
-        "name": "__DirectiveLocation",
-        "enumValues": [
-          {
             "isDeprecated": false,
             "deprecationReason": null,
-            "name": "ARGUMENT_DEFINITION",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "ENUM",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "ENUM_VALUE",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "FIELD",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "FIELD_DEFINITION",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "FRAGMENT_DEFINITION",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "FRAGMENT_SPREAD",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "INLINE_FRAGMENT",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "INPUT_FIELD_DEFINITION",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "INPUT_OBJECT",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "INTERFACE",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "MUTATION",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "OBJECT",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "QUERY",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "SCALAR",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "SCHEMA",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "SUBSCRIPTION",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "UNION",
-            "description": null
+            "__typename": "__Field"
           }
         ],
-        "description": null,
-        "fields": null
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "ENUM",
+        "name": "__DirectiveLocation",
+        "description": null,
+        "fields": null,
         "inputFields": null,
-        "kind": "OBJECT",
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ARGUMENT_DEFINITION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "ENUM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "ENUM_VALUE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "FIELD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "FIELD_DEFINITION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "FRAGMENT_DEFINITION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "FRAGMENT_SPREAD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "INLINE_FRAGMENT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "INPUT_FIELD_DEFINITION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "INPUT_OBJECT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "INTERFACE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "MUTATION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "OBJECT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "QUERY",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "SCALAR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "SCHEMA",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "SUBSCRIPTION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "UNION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          }
+        ],
         "possibleTypes": null,
-        "interfaces": [],
+        "__typename": "__Type"
+      },
+      {
+        "kind": "OBJECT",
         "name": "__EnumValue",
-        "enumValues": null,
         "description": null,
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "deprecationReason",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "description",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "isDeprecated",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "__Field",
-        "enumValues": null,
         "description": null,
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "args",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -702,168 +760,198 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "__InputValue",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "deprecationReason",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "description",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "isDeprecated",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "type",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "__Type",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "__InputValue",
-        "enumValues": null,
         "description": null,
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "defaultValue",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "description",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "type",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "__Type",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "__Schema",
-        "enumValues": null,
         "description": null,
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "directives",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -876,58 +964,70 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "__Directive",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "mutationType",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "__Type",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "queryType",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "__Type",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "subscriptionType",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "__Type",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "types",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -940,52 +1040,62 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "__Type",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "__Type",
-        "enumValues": null,
         "description": null,
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "description",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "enumValues",
+            "description": null,
             "args": [
               {
                 "name": "includeDeprecated",
-                "defaultValue": "false",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": null
+                "defaultValue": "false",
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "enumValues",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -995,28 +1105,34 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "__EnumValue",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "fields",
+            "description": null,
             "args": [
               {
                 "name": "includeDeprecated",
-                "defaultValue": "false",
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": null
+                "defaultValue": "false",
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "fields",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -1026,17 +1142,21 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "__Field",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "inputFields",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "LIST",
               "name": null,
@@ -1046,17 +1166,21 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "__InputValue",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "interfaces",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "LIST",
               "name": null,
@@ -1066,57 +1190,68 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "__Type",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "kind",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "ENUM",
                 "name": "__TypeKind",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "ofType",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "__Type",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "possibleTypes",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "LIST",
               "name": null,
@@ -1126,217 +1261,272 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "__Type",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          }
-        ]
-      },
-      {
-        "inputFields": null,
-        "kind": "ENUM",
-        "possibleTypes": null,
-        "interfaces": null,
-        "name": "__TypeKind",
-        "enumValues": [
-          {
             "isDeprecated": false,
             "deprecationReason": null,
-            "name": "ENUM",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "INPUT_OBJECT",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "INTERFACE",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "LIST",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "NON_NULL",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "OBJECT",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "SCALAR",
-            "description": null
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "UNION",
-            "description": null
+            "__typename": "__Field"
           }
         ],
-        "description": null,
-        "fields": null
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "ENUM",
+        "name": "__TypeKind",
+        "description": null,
+        "fields": null,
         "inputFields": null,
-        "kind": "OBJECT",
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ENUM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "INPUT_OBJECT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "INTERFACE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "LIST",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "NON_NULL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "OBJECT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "SCALAR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "UNION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          }
+        ],
         "possibleTypes": null,
-        "interfaces": [],
+        "__typename": "__Type"
+      },
+      {
+        "kind": "OBJECT",
         "name": "benchmarks",
-        "enumValues": null,
         "description": "columns and relationships of \"benchmarks\"",
         "fields": [
           {
+            "name": "benchmark_name",
+            "description": null,
             "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "branch",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
+            "name": "branch",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "commit",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "metrics",
+            "description": null,
             "args": [
               {
                 "name": "path",
-                "defaultValue": null,
+                "description": "JSON select path",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "JSON select path"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "metrics",
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
-            "name": "name",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "description": null
+            "__typename": "__Field"
           },
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "repo_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "run_at",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "timestamp",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
+            "name": "test_name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
+            },
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_aggregate",
-        "enumValues": null,
         "description": "aggregated selection of \"benchmarks\"",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "aggregate",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_aggregate_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "nodes",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -1349,41 +1539,52 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmarks",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_aggregate_fields",
-        "enumValues": null,
         "description": "aggregate fields of \"benchmarks\"",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "avg",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_avg_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "count",
+            "description": null,
             "args": [
               {
                 "name": "columns",
-                "defaultValue": null,
+                "description": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -1393,290 +1594,349 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarks_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": null
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "distinct",
-                "defaultValue": null,
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": null
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "count",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "max",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_max_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "min",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_min_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "stddev",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_stddev_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "stddev_pop",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_stddev_pop_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "stddev_samp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_stddev_samp_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "sum",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_sum_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "var_pop",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_var_pop_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "var_samp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_var_samp_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "variance",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_variance_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_aggregate_order_by",
+        "description": "order by aggregate values of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "avg",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_avg_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "count",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "max",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_max_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "min",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_min_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "stddev",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_stddev_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "stddev_pop",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_stddev_pop_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "stddev_samp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_stddev_samp_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "sum",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_sum_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "var_pop",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_var_pop_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "var_samp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_var_samp_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "variance",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_variance_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_aggregate_order_by",
         "enumValues": null,
-        "description": "order by aggregate values of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_append_input",
+        "description": "append existing jsonb value of filtered columns with new jsonb value",
+        "fields": null,
         "inputFields": [
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_append_input",
         "enumValues": null,
-        "description": "append existing jsonb value of filtered columns with new jsonb value",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_arr_rel_insert_input",
+        "description": "input type for inserting array relation for remote table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "data",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -1689,692 +1949,877 @@
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmarks_insert_input",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_arr_rel_insert_input",
         "enumValues": null,
-        "description": "input type for inserting array relation for remote table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_avg_fields",
-        "enumValues": null,
         "description": "aggregate avg on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_avg_order_by",
+        "description": "order by avg() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_avg_order_by",
         "enumValues": null,
-        "description": "order by avg() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_bool_exp",
+        "description": "Boolean expression to filter rows from the table \"benchmarks\". All fields are combined with a logical 'AND'.",
+        "fields": null,
         "inputFields": [
           {
             "name": "_and",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmarks_bool_exp",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_not",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarks_bool_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_or",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmarks_bool_exp",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "benchmark_name",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "jsonb_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "name": "name",
             "defaultValue": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "String_comparison_exp",
-              "ofType": null
-            },
-            "description": null
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "Int_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "repo_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "timestamp_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "test_name",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_bool_exp",
         "enumValues": null,
-        "description": "Boolean expression to filter rows from the table \"benchmarks\". All fields are combined with a logical 'AND'.",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_delete_at_path_input",
+        "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
+        "fields": null,
         "inputFields": [
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_delete_at_path_input",
         "enumValues": null,
-        "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_delete_elem_input",
+        "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
+        "fields": null,
         "inputFields": [
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_delete_elem_input",
         "enumValues": null,
-        "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_delete_key_input",
+        "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
+        "fields": null,
         "inputFields": [
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_delete_key_input",
         "enumValues": null,
-        "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_inc_input",
+        "description": "input type for incrementing integer column in table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_inc_input",
         "enumValues": null,
-        "description": "input type for incrementing integer column in table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_insert_input",
+        "description": "input type for inserting data into table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
-            "name": "branch",
-            "defaultValue": null,
+            "name": "benchmark_name",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "branch",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "name": "name",
             "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "description": null
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "repo_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "test_name",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_insert_input",
         "enumValues": null,
-        "description": "input type for inserting data into table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_max_fields",
-        "enumValues": null,
         "description": "aggregate max on columns",
         "fields": [
           {
+            "name": "benchmark_name",
+            "description": null,
             "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "branch",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "commit",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
-            "name": "name",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "description": null
+            "__typename": "__Field"
           },
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "repo_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "run_at",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
+            "name": "test_name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_max_order_by",
+        "description": "order by max() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
-            "name": "branch",
-            "defaultValue": null,
+            "name": "benchmark_name",
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "branch",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "name": "name",
             "defaultValue": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "description": null
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "repo_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "test_name",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_max_order_by",
         "enumValues": null,
-        "description": "order by max() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_min_fields",
-        "enumValues": null,
         "description": "aggregate min on columns",
         "fields": [
           {
+            "name": "benchmark_name",
+            "description": null,
             "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "branch",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "commit",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
-            "name": "name",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "description": null
+            "__typename": "__Field"
           },
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "repo_id",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "run_at",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
+            "name": "test_name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_min_order_by",
+        "description": "order by min() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
-            "name": "branch",
-            "defaultValue": null,
+            "name": "benchmark_name",
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "branch",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "name": "name",
             "defaultValue": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "description": null
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "repo_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "test_name",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_min_order_by",
         "enumValues": null,
-        "description": "order by min() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_mutation_response",
-        "enumValues": null,
         "description": "response of any mutation on the table \"benchmarks\"",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "affected_rows",
+            "description": "number of affected rows by the mutation",
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "number of affected rows by the mutation"
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "returning",
+            "description": "data of the affected rows by the mutation",
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -2387,705 +2832,846 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmarks",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "data of the affected rows by the mutation"
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_obj_rel_insert_input",
+        "description": "input type for inserting object relation for remote table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "data",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmarks_insert_input",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_obj_rel_insert_input",
         "enumValues": null,
-        "description": "input type for inserting object relation for remote table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_order_by",
+        "description": "ordering options when selecting data from \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
-            "name": "branch",
-            "defaultValue": null,
+            "name": "benchmark_name",
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "branch",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "name": "name",
             "defaultValue": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "description": null
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "repo_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "test_name",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_order_by",
         "enumValues": null,
-        "description": "ordering options when selecting data from \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_prepend_input",
+        "description": "prepend existing jsonb value of filtered columns with new jsonb value",
+        "fields": null,
         "inputFields": [
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_prepend_input",
         "enumValues": null,
-        "description": "prepend existing jsonb value of filtered columns with new jsonb value",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "ENUM",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "benchmarks_select_column",
+        "description": "select columns of table \"benchmarks\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
         "enumValues": [
           {
+            "name": "benchmark_name",
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "branch",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "commit",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "metrics",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
-            "name": "name",
-            "description": "column name"
+            "__typename": "__EnumValue"
           },
           {
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "repo_id",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "run_at",
-            "description": "column name"
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "test_name",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
           }
         ],
-        "description": "select columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_set_input",
+        "description": "input type for updating data in table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
-            "name": "branch",
-            "defaultValue": null,
+            "name": "benchmark_name",
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "branch",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commit",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "metrics",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "name": "name",
             "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "description": null
+            "__typename": "__InputValue"
           },
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "repo_id",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "run_at",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "test_name",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_set_input",
         "enumValues": null,
-        "description": "input type for updating data in table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_stddev_fields",
-        "enumValues": null,
         "description": "aggregate stddev on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_stddev_order_by",
+        "description": "order by stddev() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_stddev_order_by",
         "enumValues": null,
-        "description": "order by stddev() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_stddev_pop_fields",
-        "enumValues": null,
         "description": "aggregate stddev_pop on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_stddev_pop_order_by",
+        "description": "order by stddev_pop() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_stddev_pop_order_by",
         "enumValues": null,
-        "description": "order by stddev_pop() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_stddev_samp_fields",
-        "enumValues": null,
         "description": "aggregate stddev_samp on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_stddev_samp_order_by",
+        "description": "order by stddev_samp() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_stddev_samp_order_by",
         "enumValues": null,
-        "description": "order by stddev_samp() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_sum_fields",
-        "enumValues": null,
         "description": "aggregate sum on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_sum_order_by",
+        "description": "order by sum() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_sum_order_by",
         "enumValues": null,
-        "description": "order by sum() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_var_pop_fields",
-        "enumValues": null,
         "description": "aggregate var_pop on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_var_pop_order_by",
+        "description": "order by var_pop() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_var_pop_order_by",
         "enumValues": null,
-        "description": "order by var_pop() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_var_samp_fields",
-        "enumValues": null,
         "description": "aggregate var_samp on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_var_samp_order_by",
+        "description": "order by var_samp() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_var_samp_order_by",
         "enumValues": null,
-        "description": "order by var_samp() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarks_variance_fields",
-        "enumValues": null,
         "description": "aggregate variance on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "pull_number",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarks_variance_order_by",
+        "description": "order by variance() on columns of table \"benchmarks\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "pull_number",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarks_variance_order_by",
         "enumValues": null,
-        "description": "order by variance() on columns of table \"benchmarks\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarksrun",
-        "enumValues": null,
         "description": "columns and relationships of \"benchmarksrun\"",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "branch",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "commits",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "mbs_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "ops_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "time",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "timestamp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarksrun_aggregate",
-        "enumValues": null,
         "description": "aggregated selection of \"benchmarksrun\"",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "aggregate",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarksrun_aggregate_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "nodes",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3098,41 +3684,52 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmarksrun",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarksrun_aggregate_fields",
-        "enumValues": null,
         "description": "aggregate fields of \"benchmarksrun\"",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "avg",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarksrun_avg_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "count",
+            "description": null,
             "args": [
               {
                 "name": "columns",
-                "defaultValue": null,
+                "description": null,
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -3142,269 +3739,325 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarksrun_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": null
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "distinct",
-                "defaultValue": null,
+                "description": null,
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": null
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "count",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "max",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarksrun_max_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "min",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarksrun_min_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "stddev",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarksrun_stddev_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "stddev_pop",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarksrun_stddev_pop_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "stddev_samp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarksrun_stddev_samp_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "sum",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarksrun_sum_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "var_pop",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarksrun_var_pop_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "var_samp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarksrun_var_samp_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "variance",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "benchmarksrun_variance_fields",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_aggregate_order_by",
+        "description": "order by aggregate values of table \"benchmarksrun\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "avg",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarksrun_avg_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "count",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "max",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarksrun_max_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "min",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarksrun_min_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "stddev",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarksrun_stddev_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "stddev_pop",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarksrun_stddev_pop_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "stddev_samp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarksrun_stddev_samp_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "sum",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarksrun_sum_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "var_pop",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarksrun_var_pop_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "var_samp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarksrun_var_samp_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "variance",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarksrun_variance_order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_aggregate_order_by",
         "enumValues": null,
-        "description": "order by aggregate values of table \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_arr_rel_insert_input",
+        "description": "input type for inserting array relation for remote table \"benchmarksrun\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "data",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -3417,765 +4070,890 @@
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmarksrun_insert_input",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_arr_rel_insert_input",
         "enumValues": null,
-        "description": "input type for inserting array relation for remote table \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarksrun_avg_fields",
-        "enumValues": null,
         "description": "aggregate avg on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "mbs_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "ops_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "time",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "timestamp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_avg_order_by",
+        "description": "order by avg() on columns of table \"benchmarksrun\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "mbs_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "ops_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "time",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "timestamp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_avg_order_by",
         "enumValues": null,
-        "description": "order by avg() on columns of table \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_bool_exp",
+        "description": "Boolean expression to filter rows from the table \"benchmarksrun\". All fields are combined with a logical 'AND'.",
+        "fields": null,
         "inputFields": [
           {
             "name": "_and",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmarksrun_bool_exp",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_not",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "benchmarksrun_bool_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_or",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmarksrun_bool_exp",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commits",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "mbs_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "float8_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "String_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "ops_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "float8_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "time",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "float8_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "timestamp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "float8_comparison_exp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_bool_exp",
         "enumValues": null,
-        "description": "Boolean expression to filter rows from the table \"benchmarksrun\". All fields are combined with a logical 'AND'.",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": [
-          {
-            "name": "mbs_per_sec",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "float8",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
-            "name": "ops_per_sec",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "float8",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
-            "name": "time",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "float8",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
-            "name": "timestamp",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "float8",
-              "ofType": null
-            },
-            "description": null
-          }
-        ],
         "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "benchmarksrun_inc_input",
-        "enumValues": null,
         "description": "input type for incrementing integer column in table \"benchmarksrun\"",
-        "fields": null
-      },
-      {
+        "fields": null,
         "inputFields": [
           {
-            "name": "branch",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
-            "name": "commits",
-            "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "description": null
-          },
-          {
             "name": "mbs_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "name": "name",
             "defaultValue": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "description": null
+            "__typename": "__InputValue"
           },
           {
             "name": "ops_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "time",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "timestamp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_insert_input",
         "enumValues": null,
-        "description": "input type for inserting data into table \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
-        "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
-        "name": "benchmarksrun_max_fields",
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_insert_input",
+        "description": "input type for inserting data into table \"benchmarksrun\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "branch",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "commits",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "mbs_per_sec",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "float8",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "ops_per_sec",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "float8",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "time",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "float8",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          },
+          {
+            "name": "timestamp",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "float8",
+              "ofType": null,
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
+      },
+      {
+        "kind": "OBJECT",
+        "name": "benchmarksrun_max_fields",
         "description": "aggregate max on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "branch",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "commits",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "mbs_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "ops_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "time",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "timestamp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_max_order_by",
+        "description": "order by max() on columns of table \"benchmarksrun\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commits",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "mbs_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "ops_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "time",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "timestamp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_max_order_by",
         "enumValues": null,
-        "description": "order by max() on columns of table \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarksrun_min_fields",
-        "enumValues": null,
         "description": "aggregate min on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "branch",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "commits",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "mbs_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "name",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "ops_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "time",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "timestamp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_min_order_by",
+        "description": "order by min() on columns of table \"benchmarksrun\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commits",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "mbs_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "ops_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "time",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "timestamp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_min_order_by",
         "enumValues": null,
-        "description": "order by min() on columns of table \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarksrun_mutation_response",
-        "enumValues": null,
         "description": "response of any mutation on the table \"benchmarksrun\"",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "affected_rows",
+            "description": "number of affected rows by the mutation",
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "number of affected rows by the mutation"
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "returning",
+            "description": "data of the affected rows by the mutation",
+            "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -4188,1070 +4966,1260 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmarksrun",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "data of the affected rows by the mutation"
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_obj_rel_insert_input",
+        "description": "input type for inserting object relation for remote table \"benchmarksrun\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "data",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "INPUT_OBJECT",
                 "name": "benchmarksrun_insert_input",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_obj_rel_insert_input",
         "enumValues": null,
-        "description": "input type for inserting object relation for remote table \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_order_by",
+        "description": "ordering options when selecting data from \"benchmarksrun\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commits",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "mbs_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "ops_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "time",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "timestamp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_order_by",
         "enumValues": null,
-        "description": "ordering options when selecting data from \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "ENUM",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "benchmarksrun_select_column",
+        "description": "select columns of table \"benchmarksrun\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
         "enumValues": [
           {
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "branch",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "commits",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "mbs_per_sec",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "name",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "ops_per_sec",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "time",
-            "description": "column name"
-          },
-          {
+            "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
             "name": "timestamp",
-            "description": "column name"
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
           }
         ],
-        "description": "select columns of table \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_set_input",
+        "description": "input type for updating data in table \"benchmarksrun\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "branch",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "commits",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "mbs_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "name",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "ops_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "time",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "timestamp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_set_input",
         "enumValues": null,
-        "description": "input type for updating data in table \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarksrun_stddev_fields",
-        "enumValues": null,
         "description": "aggregate stddev on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "mbs_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "ops_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "time",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "timestamp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_stddev_order_by",
+        "description": "order by stddev() on columns of table \"benchmarksrun\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "mbs_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "ops_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "time",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "timestamp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_stddev_order_by",
         "enumValues": null,
-        "description": "order by stddev() on columns of table \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarksrun_stddev_pop_fields",
-        "enumValues": null,
         "description": "aggregate stddev_pop on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "mbs_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "ops_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "time",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "timestamp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_stddev_pop_order_by",
+        "description": "order by stddev_pop() on columns of table \"benchmarksrun\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "mbs_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "ops_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "time",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "timestamp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_stddev_pop_order_by",
         "enumValues": null,
-        "description": "order by stddev_pop() on columns of table \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarksrun_stddev_samp_fields",
-        "enumValues": null,
         "description": "aggregate stddev_samp on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "mbs_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "ops_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "time",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "timestamp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_stddev_samp_order_by",
+        "description": "order by stddev_samp() on columns of table \"benchmarksrun\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "mbs_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "ops_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "time",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "timestamp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_stddev_samp_order_by",
         "enumValues": null,
-        "description": "order by stddev_samp() on columns of table \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarksrun_sum_fields",
-        "enumValues": null,
         "description": "aggregate sum on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "mbs_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "ops_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "time",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "timestamp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_sum_order_by",
+        "description": "order by sum() on columns of table \"benchmarksrun\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "mbs_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "ops_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "time",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "timestamp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_sum_order_by",
         "enumValues": null,
-        "description": "order by sum() on columns of table \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarksrun_var_pop_fields",
-        "enumValues": null,
         "description": "aggregate var_pop on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "mbs_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "ops_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "time",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "timestamp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_var_pop_order_by",
+        "description": "order by var_pop() on columns of table \"benchmarksrun\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "mbs_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "ops_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "time",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "timestamp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_var_pop_order_by",
         "enumValues": null,
-        "description": "order by var_pop() on columns of table \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarksrun_var_samp_fields",
-        "enumValues": null,
         "description": "aggregate var_samp on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "mbs_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "ops_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "time",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "timestamp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_var_samp_order_by",
+        "description": "order by var_samp() on columns of table \"benchmarksrun\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "mbs_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "ops_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "time",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "timestamp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_var_samp_order_by",
         "enumValues": null,
-        "description": "order by var_samp() on columns of table \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "benchmarksrun_variance_fields",
-        "enumValues": null,
         "description": "aggregate variance on columns",
         "fields": [
           {
-            "args": [],
-            "isDeprecated": false,
-            "deprecationReason": null,
             "name": "mbs_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "ops_per_sec",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "time",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
-          },
-          {
-            "args": [],
             "isDeprecated": false,
             "deprecationReason": null,
+            "__typename": "__Field"
+          },
+          {
             "name": "timestamp",
+            "description": null,
+            "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Float",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "benchmarksrun_variance_order_by",
+        "description": "order by variance() on columns of table \"benchmarksrun\"",
+        "fields": null,
         "inputFields": [
           {
             "name": "mbs_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "ops_per_sec",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "time",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "timestamp",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "benchmarksrun_variance_order_by",
         "enumValues": null,
-        "description": "order by variance() on columns of table \"benchmarksrun\"",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "SCALAR",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "float8",
-        "enumValues": null,
         "description": null,
-        "fields": null
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "float8_comparison_exp",
+        "description": "expression to compare columns of type float8. All fields are combined with logical 'AND'.",
+        "fields": null,
         "inputFields": [
           {
             "name": "_eq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_in",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -5261,55 +6229,67 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "float8",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_is_null",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_neq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "float8",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_nin",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -5319,96 +6299,114 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "float8",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "float8_comparison_exp",
         "enumValues": null,
-        "description": "expression to compare columns of type float8. All fields are combined with logical 'AND'.",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "SCALAR",
-        "possibleTypes": null,
-        "interfaces": null,
         "name": "jsonb",
-        "enumValues": null,
         "description": null,
-        "fields": null
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "jsonb_comparison_exp",
+        "description": "expression to compare columns of type jsonb. All fields are combined with logical 'AND'.",
+        "fields": null,
         "inputFields": [
           {
             "name": "_contained_in",
-            "defaultValue": null,
+            "description": "is the column contained in the given json value",
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "is the column contained in the given json value"
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_contains",
-            "defaultValue": null,
+            "description": "does the column contain the given json value at the top level",
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "does the column contain the given json value at the top level"
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_eq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_has_key",
-            "defaultValue": null,
+            "description": "does the string exist as a top-level key in the column",
             "type": {
               "kind": "SCALAR",
               "name": "String",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "does the string exist as a top-level key in the column"
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_has_keys_all",
-            "defaultValue": null,
+            "description": "do all of these strings exist as top-level keys in the column",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -5418,15 +6416,19 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "do all of these strings exist as top-level keys in the column"
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_has_keys_any",
-            "defaultValue": null,
+            "description": "do any of these strings exist as top-level keys in the column",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -5436,15 +6438,19 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "do any of these strings exist as top-level keys in the column"
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_in",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -5454,55 +6460,67 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "jsonb",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_is_null",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_neq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "jsonb",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_nin",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -5512,89 +6530,98 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "jsonb",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "jsonb_comparison_exp",
         "enumValues": null,
-        "description": "expression to compare columns of type jsonb. All fields are combined with logical 'AND'.",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "mutation_root",
-        "enumValues": null,
         "description": "mutation root",
         "fields": [
           {
+            "name": "delete_benchmarks",
+            "description": "delete data from the table: \"benchmarks\"",
             "args": [
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows which have to be deleted",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmarks_bool_exp",
-                    "ofType": null
-                  }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows which have to be deleted"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "delete_benchmarks",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_mutation_response",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "delete data from the table: \"benchmarks\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "delete_benchmarksrun",
+            "description": "delete data from the table: \"benchmarksrun\"",
             "args": [
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows which have to be deleted",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmarksrun_bool_exp",
-                    "ofType": null
-                  }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows which have to be deleted"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "delete_benchmarksrun",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarksrun_mutation_response",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "delete data from the table: \"benchmarksrun\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "insert_benchmarks",
+            "description": "insert data into the table: \"benchmarks\"",
             "args": [
               {
                 "name": "objects",
-                "defaultValue": null,
+                "description": "the rows to be inserted",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -5607,56 +6634,68 @@
                       "ofType": {
                         "kind": "INPUT_OBJECT",
                         "name": "benchmarks_insert_input",
-                        "ofType": null
-                      }
-                    }
-                  }
+                        "ofType": null,
+                        "__typename": "__Type"
+                      },
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "the rows to be inserted"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "insert_benchmarks",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_mutation_response",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "insert data into the table: \"benchmarks\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "insert_benchmarks_one",
+            "description": "insert a single row into the table: \"benchmarks\"",
             "args": [
               {
                 "name": "object",
-                "defaultValue": null,
+                "description": "the row to be inserted",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmarks_insert_input",
-                    "ofType": null
-                  }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "the row to be inserted"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "insert_benchmarks_one",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "insert a single row into the table: \"benchmarks\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "insert_benchmarksrun",
+            "description": "insert data into the table: \"benchmarksrun\"",
             "args": [
               {
                 "name": "objects",
-                "defaultValue": null,
+                "description": "the rows to be inserted",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -5669,258 +6708,306 @@
                       "ofType": {
                         "kind": "INPUT_OBJECT",
                         "name": "benchmarksrun_insert_input",
-                        "ofType": null
-                      }
-                    }
-                  }
+                        "ofType": null,
+                        "__typename": "__Type"
+                      },
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "the rows to be inserted"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "insert_benchmarksrun",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarksrun_mutation_response",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "insert data into the table: \"benchmarksrun\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "insert_benchmarksrun_one",
+            "description": "insert a single row into the table: \"benchmarksrun\"",
             "args": [
               {
                 "name": "object",
-                "defaultValue": null,
+                "description": "the row to be inserted",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmarksrun_insert_input",
-                    "ofType": null
-                  }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "the row to be inserted"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "insert_benchmarksrun_one",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarksrun",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "insert a single row into the table: \"benchmarksrun\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "update_benchmarks",
+            "description": "update data of the table: \"benchmarks\"",
             "args": [
               {
                 "name": "_append",
-                "defaultValue": null,
+                "description": "append existing jsonb value of filtered columns with new jsonb value",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_append_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "append existing jsonb value of filtered columns with new jsonb value"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "_delete_at_path",
-                "defaultValue": null,
+                "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_delete_at_path_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "_delete_elem",
-                "defaultValue": null,
+                "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_delete_elem_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "_delete_key",
-                "defaultValue": null,
+                "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_delete_key_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "delete key/value pair or string element. key/value pairs are matched based on their key value"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "_inc",
-                "defaultValue": null,
+                "description": "increments the integer columns with given value of the filtered values",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_inc_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "increments the integer columns with given value of the filtered values"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "_prepend",
-                "defaultValue": null,
+                "description": "prepend existing jsonb value of filtered columns with new jsonb value",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_prepend_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "prepend existing jsonb value of filtered columns with new jsonb value"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "_set",
-                "defaultValue": null,
+                "description": "sets the columns of the filtered rows to the given values",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_set_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "sets the columns of the filtered rows to the given values"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows which have to be updated",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmarks_bool_exp",
-                    "ofType": null
-                  }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows which have to be updated"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "update_benchmarks",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarks_mutation_response",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "update data of the table: \"benchmarks\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "update_benchmarksrun",
+            "description": "update data of the table: \"benchmarksrun\"",
             "args": [
               {
                 "name": "_inc",
-                "defaultValue": null,
+                "description": "increments the integer columns with given value of the filtered values",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarksrun_inc_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "increments the integer columns with given value of the filtered values"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "_set",
-                "defaultValue": null,
+                "description": "sets the columns of the filtered rows to the given values",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarksrun_set_input",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "sets the columns of the filtered rows to the given values"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows which have to be updated",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "benchmarksrun_bool_exp",
-                    "ofType": null
-                  }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows which have to be updated"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "update_benchmarksrun",
             "type": {
               "kind": "OBJECT",
               "name": "benchmarksrun_mutation_response",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": "update data of the table: \"benchmarksrun\""
-          }
-        ]
-      },
-      {
-        "inputFields": null,
-        "kind": "ENUM",
-        "possibleTypes": null,
-        "interfaces": null,
-        "name": "order_by",
-        "enumValues": [
-          {
             "isDeprecated": false,
             "deprecationReason": null,
-            "name": "asc",
-            "description": "in the ascending order, nulls last"
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "asc_nulls_first",
-            "description": "in the ascending order, nulls first"
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "asc_nulls_last",
-            "description": "in the ascending order, nulls last"
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "desc",
-            "description": "in the descending order, nulls first"
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "desc_nulls_first",
-            "description": "in the descending order, nulls first"
-          },
-          {
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "desc_nulls_last",
-            "description": "in the descending order, nulls last"
+            "__typename": "__Field"
           }
         ],
-        "description": "column ordering options",
-        "fields": null
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "ENUM",
+        "name": "order_by",
+        "description": "column ordering options",
+        "fields": null,
         "inputFields": null,
-        "kind": "OBJECT",
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "asc",
+            "description": "in the ascending order, nulls last",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "asc_nulls_first",
+            "description": "in the ascending order, nulls first",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "asc_nulls_last",
+            "description": "in the ascending order, nulls last",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "desc",
+            "description": "in the descending order, nulls first",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "desc_nulls_first",
+            "description": "in the descending order, nulls first",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          },
+          {
+            "name": "desc_nulls_last",
+            "description": "in the descending order, nulls last",
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__EnumValue"
+          }
+        ],
         "possibleTypes": null,
-        "interfaces": [],
+        "__typename": "__Type"
+      },
+      {
+        "kind": "OBJECT",
         "name": "query_root",
-        "enumValues": null,
         "description": "query root",
         "fields": [
           {
+            "name": "benchmarks",
+            "description": "fetch data from the table: \"benchmarks\"",
             "args": [
               {
                 "name": "distinct_on",
-                "defaultValue": null,
+                "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -5930,35 +7017,43 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarks_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "distinct select on columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "limit",
-                "defaultValue": null,
+                "description": "limit the number of rows returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "limit the number of rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "offset",
-                "defaultValue": null,
+                "description": "skip the first n rows. Use only with order_by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "skip the first n rows. Use only with order_by"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "order_by",
-                "defaultValue": null,
+                "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -5968,26 +7063,29 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmarks_order_by",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "sort the rows by one or more columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_bool_exp",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmarks",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -6000,18 +7098,26 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmarks",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "fetch data from the table: \"benchmarks\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "benchmarks_aggregate",
+            "description": "fetch aggregated fields from the table: \"benchmarks\"",
             "args": [
               {
                 "name": "distinct_on",
-                "defaultValue": null,
+                "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -6021,35 +7127,43 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarks_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "distinct select on columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "limit",
-                "defaultValue": null,
+                "description": "limit the number of rows returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "limit the number of rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "offset",
-                "defaultValue": null,
+                "description": "skip the first n rows. Use only with order_by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "skip the first n rows. Use only with order_by"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "order_by",
-                "defaultValue": null,
+                "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -6059,42 +7173,51 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmarks_order_by",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "sort the rows by one or more columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_bool_exp",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmarks_aggregate",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "benchmarks_aggregate",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "fetch aggregated fields from the table: \"benchmarks\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "benchmarksrun",
+            "description": "fetch data from the table: \"benchmarksrun\"",
             "args": [
               {
                 "name": "distinct_on",
-                "defaultValue": null,
+                "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -6104,35 +7227,43 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarksrun_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "distinct select on columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "limit",
-                "defaultValue": null,
+                "description": "limit the number of rows returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "limit the number of rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "offset",
-                "defaultValue": null,
+                "description": "skip the first n rows. Use only with order_by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "skip the first n rows. Use only with order_by"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "order_by",
-                "defaultValue": null,
+                "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -6142,26 +7273,29 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmarksrun_order_by",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "sort the rows by one or more columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarksrun_bool_exp",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmarksrun",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -6174,18 +7308,26 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmarksrun",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "fetch data from the table: \"benchmarksrun\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "benchmarksrun_aggregate",
+            "description": "fetch aggregated fields from the table: \"benchmarksrun\"",
             "args": [
               {
                 "name": "distinct_on",
-                "defaultValue": null,
+                "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -6195,35 +7337,43 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarksrun_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "distinct select on columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "limit",
-                "defaultValue": null,
+                "description": "limit the number of rows returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "limit the number of rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "offset",
-                "defaultValue": null,
+                "description": "skip the first n rows. Use only with order_by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "skip the first n rows. Use only with order_by"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "order_by",
-                "defaultValue": null,
+                "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -6233,53 +7383,63 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmarksrun_order_by",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "sort the rows by one or more columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarksrun_bool_exp",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmarksrun_aggregate",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "benchmarksrun_aggregate",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "fetch aggregated fields from the table: \"benchmarksrun\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
-        "inputFields": null,
         "kind": "OBJECT",
-        "possibleTypes": null,
-        "interfaces": [],
         "name": "subscription_root",
-        "enumValues": null,
         "description": "subscription root",
         "fields": [
           {
+            "name": "benchmarks",
+            "description": "fetch data from the table: \"benchmarks\"",
             "args": [
               {
                 "name": "distinct_on",
-                "defaultValue": null,
+                "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -6289,35 +7449,43 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarks_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "distinct select on columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "limit",
-                "defaultValue": null,
+                "description": "limit the number of rows returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "limit the number of rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "offset",
-                "defaultValue": null,
+                "description": "skip the first n rows. Use only with order_by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "skip the first n rows. Use only with order_by"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "order_by",
-                "defaultValue": null,
+                "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -6327,26 +7495,29 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmarks_order_by",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "sort the rows by one or more columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_bool_exp",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmarks",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -6359,18 +7530,26 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmarks",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "fetch data from the table: \"benchmarks\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "benchmarks_aggregate",
+            "description": "fetch aggregated fields from the table: \"benchmarks\"",
             "args": [
               {
                 "name": "distinct_on",
-                "defaultValue": null,
+                "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -6380,35 +7559,43 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarks_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "distinct select on columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "limit",
-                "defaultValue": null,
+                "description": "limit the number of rows returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "limit the number of rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "offset",
-                "defaultValue": null,
+                "description": "skip the first n rows. Use only with order_by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "skip the first n rows. Use only with order_by"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "order_by",
-                "defaultValue": null,
+                "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -6418,42 +7605,51 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmarks_order_by",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "sort the rows by one or more columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarks_bool_exp",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmarks_aggregate",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "benchmarks_aggregate",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "fetch aggregated fields from the table: \"benchmarks\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "benchmarksrun",
+            "description": "fetch data from the table: \"benchmarksrun\"",
             "args": [
               {
                 "name": "distinct_on",
-                "defaultValue": null,
+                "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -6463,35 +7659,43 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarksrun_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "distinct select on columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "limit",
-                "defaultValue": null,
+                "description": "limit the number of rows returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "limit the number of rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "offset",
-                "defaultValue": null,
+                "description": "skip the first n rows. Use only with order_by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "skip the first n rows. Use only with order_by"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "order_by",
-                "defaultValue": null,
+                "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -6501,26 +7705,29 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmarksrun_order_by",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "sort the rows by one or more columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarksrun_bool_exp",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmarksrun",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -6533,18 +7740,26 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "benchmarksrun",
-                    "ofType": null
-                  }
-                }
-              }
+                    "ofType": null,
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "fetch data from the table: \"benchmarksrun\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           },
           {
+            "name": "benchmarksrun_aggregate",
+            "description": "fetch aggregated fields from the table: \"benchmarksrun\"",
             "args": [
               {
                 "name": "distinct_on",
-                "defaultValue": null,
+                "description": "distinct select on columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -6554,35 +7769,43 @@
                     "ofType": {
                       "kind": "ENUM",
                       "name": "benchmarksrun_select_column",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "distinct select on columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "limit",
-                "defaultValue": null,
+                "description": "limit the number of rows returned",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "limit the number of rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "offset",
-                "defaultValue": null,
+                "description": "skip the first n rows. Use only with order_by",
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "skip the first n rows. Use only with order_by"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "order_by",
-                "defaultValue": null,
+                "description": "sort the rows by one or more columns",
                 "type": {
                   "kind": "LIST",
                   "name": null,
@@ -6592,84 +7815,107 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "benchmarksrun_order_by",
-                      "ofType": null
-                    }
-                  }
+                      "ofType": null,
+                      "__typename": "__Type"
+                    },
+                    "__typename": "__Type"
+                  },
+                  "__typename": "__Type"
                 },
-                "description": "sort the rows by one or more columns"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               },
               {
                 "name": "where",
-                "defaultValue": null,
+                "description": "filter the rows returned",
                 "type": {
                   "kind": "INPUT_OBJECT",
                   "name": "benchmarksrun_bool_exp",
-                  "ofType": null
+                  "ofType": null,
+                  "__typename": "__Type"
                 },
-                "description": "filter the rows returned"
+                "defaultValue": null,
+                "__typename": "__InputValue"
               }
             ],
-            "isDeprecated": false,
-            "deprecationReason": null,
-            "name": "benchmarksrun_aggregate",
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
                 "name": "benchmarksrun_aggregate",
-                "ofType": null
-              }
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": "fetch aggregated fields from the table: \"benchmarksrun\""
+            "isDeprecated": false,
+            "deprecationReason": null,
+            "__typename": "__Field"
           }
-        ]
-      },
-      {
+        ],
         "inputFields": null,
-        "kind": "SCALAR",
-        "possibleTypes": null,
-        "interfaces": null,
-        "name": "timestamp",
+        "interfaces": [],
         "enumValues": null,
-        "description": null,
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       },
       {
+        "kind": "SCALAR",
+        "name": "timestamp",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null,
+        "__typename": "__Type"
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "timestamp_comparison_exp",
+        "description": "expression to compare columns of type timestamp. All fields are combined with logical 'AND'.",
+        "fields": null,
         "inputFields": [
           {
             "name": "_eq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_gte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_in",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -6679,55 +7925,67 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "timestamp",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_is_null",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lt",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_lte",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_neq",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "timestamp",
-              "ofType": null
+              "ofType": null,
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           },
           {
             "name": "_nin",
-            "defaultValue": null,
+            "description": null,
             "type": {
               "kind": "LIST",
               "name": null,
@@ -6737,24 +7995,83 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "timestamp",
-                  "ofType": null
-                }
-              }
+                  "ofType": null,
+                  "__typename": "__Type"
+                },
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
             },
-            "description": null
+            "defaultValue": null,
+            "__typename": "__InputValue"
           }
         ],
-        "kind": "INPUT_OBJECT",
-        "possibleTypes": null,
         "interfaces": null,
-        "name": "timestamp_comparison_exp",
         "enumValues": null,
-        "description": "expression to compare columns of type timestamp. All fields are combined with logical 'AND'.",
-        "fields": null
+        "possibleTypes": null,
+        "__typename": "__Type"
       }
     ],
-    "mutationType": {
-      "name": "mutation_root"
-    }
+    "directives": [
+      {
+        "name": "include",
+        "description": null,
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
+        "args": [
+          {
+            "name": "if",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          }
+        ],
+        "__typename": "__Directive"
+      },
+      {
+        "name": "skip",
+        "description": null,
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
+        "args": [
+          {
+            "name": "if",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null,
+                "__typename": "__Type"
+              },
+              "__typename": "__Type"
+            },
+            "defaultValue": null,
+            "__typename": "__InputValue"
+          }
+        ],
+        "__typename": "__Directive"
+      }
+    ],
+    "__typename": "__Schema"
   }
 }

--- a/frontend-new/src/App.res
+++ b/frontend-new/src/App.res
@@ -8,6 +8,7 @@ module GetBenchmarks = %graphql(`
 query ($startDate: timestamp!, $endDate: timestamp!) {
   benchmarks(where: {_and: [{run_at: {_gte: $startDate}}, {run_at: {_lt: $endDate}}]}) {
       repo_id
+      test_name
       metrics
       commit
       branch
@@ -27,7 +28,7 @@ let collectBranches = (data: array<GetBenchmarks.t_benchmarks>) => {
 
 let getTestMetrics = (item: GetBenchmarks.t_benchmarks): BenchmarkTest.testMetrics => {
   {
-    BenchmarkTest.name: item.repo_id,
+    BenchmarkTest.name: item.test_name,
     metrics: item.metrics
     ->Belt.Option.getExn
     ->Js.Json.decodeObject


### PR DESCRIPTION
Extends the benchmarks schema to support benchmark and test names. Fixes the UI issue mentioned in https://github.com/ocurrent/current-bench/pull/28#discussion_r567280196.